### PR TITLE
Changed Download Folder location

### DIFF
--- a/root/etc/config/core.conf
+++ b/root/etc/config/core.conf
@@ -16,7 +16,7 @@
     "del_copy_torrent_file": false,
     "dht": true,
     "dont_count_slow_torrents": false,
-    "download_location": "/download/incomplete",
+    "download_location": "/download",
     "download_location_paths_list": [],
     "enabled_plugins": [
         "Label"


### PR DESCRIPTION
Ensure the `download_location` is tracked as _incomplete_ specifically, rather than the download root.

@Nayrboh well-spotted.